### PR TITLE
Fixing typos in help: Readme and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ Options:
                                              r,root:  clone root
   -C --color=<xxx>      Set color scheme to off|low|low2|bw|dark|high
   -E --encrypt          Set up to boot from an encrypted partition
-  --encrypt=<flag>      Phasephrase option:
+  --encrypt=<flag>      Passphrase option:
                            ask         Enter the passphrase via the keyboard
                            first-boot  Force user to set phrase on first boot
                            file=xxx    Read phrase from file <xxx>
                            random      Generate a random passphrase
-                           random=N    Generate a random passhphrase containing
+                           random=N    Generate a random passphrase containing
                                        N words (1 -- 20 allowed)
 
   -e --esp-size=<xx>    Size of ESP (uefi) partition in MiB (default 50)

--- a/dd-live-usb
+++ b/dd-live-usb
@@ -41,7 +41,7 @@ usage() {
 cat<<Usage
 Usage: $ME [<options>]
 
-A save and convenient way to make a "dd" live-usb from a .iso file.
+A safe and convenient way to make a "dd" live-usb from a .iso file.
 Will prompt you for the file and for the device to write to if they
 are not given on the command line.
 

--- a/live-usb-maker
+++ b/live-usb-maker
@@ -168,12 +168,12 @@ Options:
                                              r,root:  clone root
   -C --color=<xxx>      Set color scheme to off|low|low2|bw|dark|high
   -E --encrypt          Set up to boot from an encrypted partition
-  --encrypt=<flag>      Phasephrase option:
+  --encrypt=<flag>      Passphrase option:
                            ask         Enter the passphrase via the keyboard
                            first-boot  Force user to set phrase on first boot
                            file=xxx    Read phrase from file <xxx>
                            random      Generate a random passphrase
-                           random=N    Generate a random passhphrase containing
+                           random=N    Generate a random passphrase containing
                                        N words (1 -- 20 allowed)
 
   -e --esp-size=<xx>    Size of ESP (uefi) partition in MiB (default 50)


### PR DESCRIPTION
Trivial, I know, but it might as well be done.